### PR TITLE
Meaningful Windows Support

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -364,6 +364,9 @@ def run_job(taskname):
             print('<?xml version="1.0" encoding="UTF-8"?>', file=f)
             print('<testsuites disabled="0" errors="%d" failures="%d" tests="1" time="%d">' % (junit_errors, junit_failures, job.total_time), file=f)
             print('<testsuite disabled="0" errors="%d" failures="%d" name="%s" skipped="0" tests="1" time="%d">' % (junit_errors, junit_failures, junit_ts_name, job.total_time), file=f)
+            print('<properties>', file=f)
+            print('<property name="os" value="%s"/>' % os.name, file=f)
+            print('</properties>', file=f)
             print('<testcase classname="%s" name="%s" status="%s" time="%d">' % (junit_ts_name, junit_tc_name, job.status, job.total_time), file=f)
             if junit_errors:
                 print('<error message="%s" type="%s"/>' % (job.status, job.status), file=f)
@@ -385,4 +388,3 @@ for t in tasknames:
     retcode |= run_job(t)
 
 sys.exit(retcode)
-

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -33,7 +33,19 @@ class SbyTask:
         self.job = job
         self.info = info
         self.deps = deps
-        self.cmdline = cmdline
+        if os.name == "posix":
+            self.cmdline = cmdline
+        else:
+            replacements = {
+                ";" : "&",
+                "{" : "(",
+                "}" : ")",
+            }
+
+            cmdline_copy = cmdline
+            for u, w in replacements.items():
+                cmdline_copy = cmdline_copy.replace(u, w)
+            self.cmdline = cmdline_copy
         self.logfile = logfile
         self.noprintregex = None
         self.notify = []

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -36,6 +36,8 @@ class SbyTask:
         if os.name == "posix":
             self.cmdline = cmdline
         else:
+            # Windows command interpreter equivalents for sequential
+            # commands (; => &) command grouping ({} => ()).
             replacements = {
                 ";" : "&",
                 "{" : "(",
@@ -598,15 +600,19 @@ class SbyJob:
             ru = resource.getrusage(resource.RUSAGE_CHILDREN)
             total_process_time = int((ru.ru_utime + ru.ru_stime) - self.start_process_time)
             self.total_time = total_process_time
-        else:
-            total_process_time = 0
 
-        self.summary = [
-            "Elapsed clock time [H:MM:SS (secs)]: %d:%02d:%02d (%d)" %
-                    (total_clock_time // (60*60), (total_clock_time // 60) % 60, total_clock_time % 60, total_clock_time),
-            "Elapsed process time [H:MM:SS (secs)]: %d:%02d:%02d (%d)" %
-                    (total_process_time // (60*60), (total_process_time // 60) % 60, total_process_time % 60, total_process_time),
-        ] + self.summary
+            self.summary = [
+                "Elapsed clock time [H:MM:SS (secs)]: %d:%02d:%02d (%d)" %
+                        (total_clock_time // (60*60), (total_clock_time // 60) % 60, total_clock_time % 60, total_clock_time),
+                "Elapsed process time [H:MM:SS (secs)]: %d:%02d:%02d (%d)" %
+                        (total_process_time // (60*60), (total_process_time // 60) % 60, total_process_time % 60, total_process_time),
+            ] + self.summary
+        else:
+            self.summary = [
+                "Elapsed clock time [H:MM:SS (secs)]: %d:%02d:%02d (%d)" %
+                        (total_clock_time // (60*60), (total_clock_time // 60) % 60, total_clock_time % 60, total_clock_time),
+                "Elapsed process time unvailable on Windows"
+            ] + self.summary
 
         for line in self.summary:
             self.log("summary: %s" % line)


### PR DESCRIPTION
This PR is not yet ready. However, I would appreciate having the changes I've pushed so far approved before continuing.

## Caveats
Strictly speaking, with the changes I've currently pushed, `sby` now works on Windows. However, the support is limited to one task per job, because the poll loop relies on `select`. `select` does not work on `fd`s on Windows, so an alternate solution is required.

Additionally, I'm not able to test the `abc`, `btor` or `aiger` engines at present; in particular, `btor` was [more complex](https://github.com/YosysHQ/SymbiYosys/compare/master...cr1901:no-resource?expand=1#diff-79c4f1bed2788c3c9c3ff133517af7deR115) to add Windows support. Thus, I'm more concerned that my refactoring doesn't break the `btor` engine on Linux.

## Changes So Far
* On Windows, `fcntl` and `resource` modules are gated out. This means the steps setting each tasks' `stdout` to non-blocking doesn't run, and process running time information is always `00:00:00`. I know of workarounds for lack of `fcntl`; I'd rather just gate out process running time on Windows.
* When constructing task command lines, use the OS to determine which command separator to use. On POSIX OSes, use `;`. On Windows, use `&` (equivalent to `&&` in POSIX).

## Next Steps
To complete this PR, I have to figure out how to handle the lack of `select` on fds to implement polling. If running multiple tasks, the current Windows behavior right now is for tasks to run sequentially rather than interleaved (but all processes are spawned. So all but one task blocks waiting to send its output back to `sby`).