### PR TITLE
Update Boolector build instructions

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -119,10 +119,8 @@ http://fmv.jku.at/boolector/
 .. code-block:: text
 
    git clone https://github.com/boolector/boolector
-   git clone https://github.com/arminbiere/lingeling boolector/deps/lingeling
-   git clone https://github.com/boolector/btor2tools boolector/deps/btor2tools
-   ( cd boolector/deps/lingeling  && ./configure.sh -fPIC && make -j$(nproc); )
-   ( cd boolector/deps/btor2tools && ./configure.sh -fPIC && make -j$(nproc); )
+   ( cd boolector && ./contrib/setup-btor2tools.sh; )
+   ( cd boolector && ./contrib/setup-lingeling.sh; )
    ( cd boolector && ./configure.sh && cd build && make -j$(nproc); )
    sudo cp boolector/build/bin/{boolector,btor*} /usr/local/bin/
    sudo cp boolector/deps/btor2tools/bin/btorsim /usr/local/bin/


### PR DESCRIPTION
It looks like the build process for Boolector has changed recently.

The btor2tools package is not found with the current instructions and configure of boolector fails as a consequence.

They have added setup scripts for btor2tools and lingeling - using those worked well, so I updated the instructions here.