### PR TITLE
Use an Asynchronous Event Loop in SbyJob

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -587,19 +587,19 @@ class SbyJob:
 
         if self.opt_mode == "bmc":
             import sby_mode_bmc
-            sby_mode_bmc.run(self)
+            sby_mode_bmc.init(self)
 
         elif self.opt_mode == "prove":
             import sby_mode_prove
-            sby_mode_prove.run(self)
+            sby_mode_prove.init(self)
 
         elif self.opt_mode == "live":
             import sby_mode_live
-            sby_mode_live.run(self)
+            sby_mode_live.init(self)
 
         elif self.opt_mode == "cover":
             import sby_mode_cover
-            sby_mode_cover.run(self)
+            sby_mode_cover.init(self)
 
         else:
             assert False

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -237,7 +237,6 @@ class SbyJob:
             loop = asyncio.ProactorEventLoop()
             asyncio.set_event_loop(loop)
         loop = asyncio.get_event_loop()
-        loop.set_debug(enabled=True)
         poll_fut = asyncio.ensure_future(self.task_poller())
         loop.run_until_complete(poll_fut)
 

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -59,16 +59,11 @@ class SbyTask:
         self.job.tasks_pending.append(self)
 
         for dep in self.deps:
-            dep.register_dep(self)
+            if not dep.finished:
+                dep.notify.append(self)
 
         self.output_callback = None
         self.exit_callback = None
-
-    def register_dep(self, next_task):
-        if self.finished:
-            next_task.poll()
-        else:
-            self.notify.append(next_task)
 
     def handle_output(self, line):
         if self.terminated or len(line) == 0:

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -92,56 +92,7 @@ class SbyTask:
             self.job.tasks_running.remove(self)
         self.terminated = True
 
-    def poll(self):
-        if self.finished or self.terminated:
-            return
-
-        if not self.running:
-            for dep in self.deps:
-                if not dep.finished:
-                    return
-
-            self.job.log("%s: starting process \"%s\"" % (self.info, self.cmdline))
-            self.p = subprocess.Popen(self.cmdline, shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-                    stderr=(subprocess.STDOUT if self.logstderr else None))
-            if os.name == "posix":
-                fl = fcntl.fcntl(self.p.stdout, fcntl.F_GETFL)
-                fcntl.fcntl(self.p.stdout, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-            self.job.tasks_pending.remove(self)
-            self.job.tasks_running.append(self)
-            self.running = True
-            return
-
-        while True:
-            outs = self.p.stdout.readline().decode("utf-8")
-            if len(outs) == 0: break
-            if outs[-1] != '\n':
-                self.linebuffer += outs
-                break
-            outs = (self.linebuffer + outs).strip()
-            self.linebuffer = ""
-            self.handle_output(outs)
-
-        if self.p.poll() is not None:
-            self.job.log("%s: finished (returncode=%d)" % (self.info, self.p.returncode))
-            self.job.tasks_running.remove(self)
-            self.running = False
-
-            self.handle_exit(self.p.returncode)
-
-            if self.checkretcode and self.p.returncode != 0:
-                self.job.status = "ERROR"
-                self.job.log("%s: job failed. ERROR." % self.info)
-                self.terminated = True
-                self.job.terminate()
-                return
-
-            self.finished = True
-            for next_task in self.notify:
-                next_task.poll()
-            return
-
-    async def output_async(self):
+    async def output(self):
         while True:
             outs = await self.p.stdout.readline()
             await asyncio.sleep(0) # https://bugs.python.org/issue24532
@@ -154,7 +105,7 @@ class SbyTask:
             self.linebuffer = ""
             self.handle_output(outs)
 
-    async def maybe_spawn_async(self):
+    async def maybe_spawn(self):
         if self.finished or self.terminated:
             return
 
@@ -170,10 +121,10 @@ class SbyTask:
             self.job.tasks_pending.remove(self)
             self.job.tasks_running.append(self)
             self.running = True
-            asyncio.ensure_future(self.output_async())
+            asyncio.ensure_future(self.output())
             self.fut = asyncio.ensure_future(self.p.wait())
 
-    async def shutdown_and_notify_async(self):
+    async def shutdown_and_notify(self):
         self.job.log("%s: finished (returncode=%d)" % (self.info, self.p.returncode))
         self.job.tasks_running.remove(self)
         self.running = False
@@ -189,7 +140,7 @@ class SbyTask:
 
         self.finished = True
         for next_task in self.notify:
-            await next_task.maybe_spawn_async()
+            await next_task.maybe_spawn()
         return
 
 class SbyAbort(BaseException):
@@ -243,34 +194,6 @@ class SbyJob:
                 print(line, file=f)
 
     def taskloop(self):
-        for task in self.tasks_pending:
-            task.poll()
-
-        while len(self.tasks_running):
-            fds = []
-            for task in self.tasks_running:
-                if task.running:
-                    fds.append(task.p.stdout)
-
-            try:
-                select(fds, [], [], 1.0) == ([], [], [])
-            except:
-                pass
-
-            for task in self.tasks_running:
-                task.poll()
-
-            for task in self.tasks_pending:
-                task.poll()
-
-            if self.opt_timeout is not None:
-                total_clock_time = int(time() - self.start_clock_time)
-                if total_clock_time > self.opt_timeout:
-                    self.log("Reached TIMEOUT (%d seconds). Terminating all tasks." % self.opt_timeout)
-                    self.status = "TIMEOUT"
-                    self.terminate(timeout=True)
-
-    def taskloop_async(self):
         if os.name != "posix":
             loop = asyncio.ProactorEventLoop()
             asyncio.set_event_loop(loop)
@@ -300,7 +223,7 @@ class SbyJob:
             timer_fut.add_done_callback(partial(SbyJob.timeout, self))
 
         for task in self.tasks_pending:
-            await task.maybe_spawn_async()
+            await task.maybe_spawn()
 
         while len(self.tasks_running):
             task_futs = []
@@ -311,7 +234,7 @@ class SbyJob:
 
             for task in self.tasks_running:
                 if task.fut in done:
-                    await task.shutdown_and_notify_async()
+                    await task.shutdown_and_notify()
 
         if self.opt_timeout is not None:
             timer_fut.cancel()
@@ -685,9 +608,7 @@ class SbyJob:
             if opt not in self.used_options:
                 self.error("Unused option: %s" % opt)
 
-        # self.taskloop()
-        self.taskloop_async()
-
+        self.taskloop()
 
         total_clock_time = int(time() - self.start_clock_time)
 

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -259,7 +259,8 @@ class SbyJob:
     async def task_poller(self):
         if self.opt_timeout is not None:
             timer_fut = asyncio.ensure_future(self.timekeeper())
-            timer_fut.add_done_callback(partial(SbyJob.timeout, self))
+            done_cb = partial(SbyJob.timeout, self)
+            timer_fut.add_done_callback(done_cb)
 
         for task in self.tasks_pending:
             await task.maybe_spawn()
@@ -276,6 +277,7 @@ class SbyJob:
                     await task.shutdown_and_notify()
 
         if self.opt_timeout is not None:
+            timer_fut.remove_done_callback(done_cb)
             timer_fut.cancel()
 
         # Required on Windows. I am unsure why, but subprocesses that were

--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -21,6 +21,7 @@ if os.name == "posix":
     import resource, fcntl
 import subprocess
 import asyncio
+from functools import partial
 from shutil import copyfile
 from select import select
 from time import time, localtime
@@ -283,7 +284,26 @@ class SbyJob:
         poll_fut = asyncio.ensure_future(self.task_poller())
         loop.run_until_complete(poll_fut)
 
+    async def timekeeper(self):
+        total_clock_time = int(time() - self.start_clock_time)
+
+        try:
+            while total_clock_time <= self.opt_timeout:
+                await asyncio.sleep(1)
+                total_clock_time = int(time() - self.start_clock_time)
+        except asyncio.CancelledError:
+            pass
+
+    def timeout(self, fut):
+        self.log("Reached TIMEOUT (%d seconds). Terminating all tasks." % self.opt_timeout)
+        self.status = "TIMEOUT"
+        self.terminate(timeout=True)
+
     async def task_poller(self):
+        if self.opt_timeout is not None:
+            timer_fut = asyncio.ensure_future(self.timekeeper())
+            timer_fut.add_done_callback(partial(SbyJob.timeout, self))
+
         for task in self.tasks_pending:
             await task.maybe_spawn_async()
 
@@ -298,16 +318,8 @@ class SbyJob:
                 if task.fut in done:
                     await task.shutdown_and_notify_async()
 
-            # for task in self.tasks_pending:
-            #     await task.poll_async()
-
-            #if self.opt_timeout is not None:
-                #total_clock_time = int(time() - self.start_clock_time)
-                #if total_clock_time > self.opt_timeout:
-                    #self.log("Reached TIMEOUT (%d seconds). Terminating all tasks." % self.opt_timeout)
-                    #self.status = "TIMEOUT"
-                    #self.terminate(timeout=True)
-
+        if self.opt_timeout is not None:
+            timer_fut.cancel()
 
     def log(self, logmessage):
         tm = localtime()

--- a/sbysrc/sby_engine_abc.py
+++ b/sbysrc/sby_engine_abc.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(mode, job, engine_idx, engine):
+def init(mode, job, engine_idx, engine):
     abc_opts, abc_command = getopt.getopt(engine[1:], "", [])
 
     if len(abc_command) == 0:
@@ -117,4 +117,3 @@ def run(mode, job, engine_idx, engine):
 
     task.output_callback = output_callback
     task.exit_callback = exit_callback
-

--- a/sbysrc/sby_engine_aiger.py
+++ b/sbysrc/sby_engine_aiger.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(mode, job, engine_idx, engine):
+def init(mode, job, engine_idx, engine):
     opts, solver_args = getopt.getopt(engine[1:], "", [])
 
     if len(solver_args) == 0:
@@ -139,4 +139,3 @@ def run(mode, job, engine_idx, engine):
 
     task.output_callback = output_callback
     task.exit_callback = exit_callback
-

--- a/sbysrc/sby_engine_btor.py
+++ b/sbysrc/sby_engine_btor.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(mode, job, engine_idx, engine):
+def init(mode, job, engine_idx, engine):
     opts, solver_args = getopt.getopt(engine[1:], "", [])
 
     if len(solver_args) == 0:
@@ -160,4 +160,3 @@ def run(mode, job, engine_idx, engine):
 
     task.output_callback = output_callback
     task.exit_callback = exit_callback
-

--- a/sbysrc/sby_engine_smtbmc.py
+++ b/sbysrc/sby_engine_smtbmc.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(mode, job, engine_idx, engine):
+def init(mode, job, engine_idx, engine):
     smtbmc_opts = []
     nomem_opt = False
     presat_opt = True
@@ -99,9 +99,9 @@ def run(mode, job, engine_idx, engine):
 
     if mode == "prove":
         if not induction_only:
-            run("prove_basecase", job, engine_idx, engine)
+            init("prove_basecase", job, engine_idx, engine)
         if not basecase_only:
-            run("prove_induction", job, engine_idx, engine)
+            init("prove_induction", job, engine_idx, engine)
         return
 
     taskname = "engine_%d" % engine_idx
@@ -210,5 +210,3 @@ def run(mode, job, engine_idx, engine):
 
     task.output_callback = output_callback
     task.exit_callback = exit_callback
-
-

--- a/sbysrc/sby_mode_bmc.py
+++ b/sbysrc/sby_mode_bmc.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(job):
+def init(job):
     job.handle_int_option("depth", 20)
     job.handle_int_option("append", 0)
     job.handle_str_option("aigsmt", "yices")
@@ -33,16 +33,15 @@ def run(job):
 
         if engine[0] == "smtbmc":
             import sby_engine_smtbmc
-            sby_engine_smtbmc.run("bmc", job, engine_idx, engine)
+            sby_engine_smtbmc.init("bmc", job, engine_idx, engine)
 
         elif engine[0] == "abc":
             import sby_engine_abc
-            sby_engine_abc.run("bmc", job, engine_idx, engine)
+            sby_engine_abc.init("bmc", job, engine_idx, engine)
 
         elif engine[0] == "btor":
             import sby_engine_btor
-            sby_engine_btor.run("bmc", job, engine_idx, engine)
+            sby_engine_btor.init("bmc", job, engine_idx, engine)
 
         else:
             job.error("Invalid engine '%s' for bmc mode." % engine[0])
-

--- a/sbysrc/sby_mode_cover.py
+++ b/sbysrc/sby_mode_cover.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(job):
+def init(job):
     job.handle_int_option("depth", 20)
     job.handle_int_option("append", 0)
 
@@ -32,8 +32,7 @@ def run(job):
 
         if engine[0] == "smtbmc":
             import sby_engine_smtbmc
-            sby_engine_smtbmc.run("cover", job, engine_idx, engine)
+            sby_engine_smtbmc.init("cover", job, engine_idx, engine)
 
         else:
             job.error("Invalid engine '%s' for cover mode." % engine[0])
-

--- a/sbysrc/sby_mode_live.py
+++ b/sbysrc/sby_mode_live.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(job):
+def init(job):
     job.handle_str_option("aigsmt", "yices")
 
     job.status = "UNKNOWN"
@@ -33,8 +33,7 @@ def run(job):
 
         if engine[0] == "aiger":
             import sby_engine_aiger
-            sby_engine_aiger.run("live", job, engine_idx, engine)
+            sby_engine_aiger.init("live", job, engine_idx, engine)
 
         else:
             job.error("Invalid engine '%s' for live mode." % engine[0])
-

--- a/sbysrc/sby_mode_prove.py
+++ b/sbysrc/sby_mode_prove.py
@@ -19,7 +19,7 @@
 import re, os, getopt
 from sby_core import SbyTask
 
-def run(job):
+def init(job):
     job.handle_int_option("depth", 20)
     job.handle_int_option("append", 0)
     job.handle_str_option("aigsmt", "yices")
@@ -40,16 +40,15 @@ def run(job):
 
         if engine[0] == "smtbmc":
             import sby_engine_smtbmc
-            sby_engine_smtbmc.run("prove", job, engine_idx, engine)
+            sby_engine_smtbmc.init("prove", job, engine_idx, engine)
 
         elif engine[0] == "aiger":
             import sby_engine_aiger
-            sby_engine_aiger.run("prove", job, engine_idx, engine)
+            sby_engine_aiger.init("prove", job, engine_idx, engine)
 
         elif engine[0] == "abc":
             import sby_engine_abc
-            sby_engine_abc.run("prove", job, engine_idx, engine)
+            sby_engine_abc.init("prove", job, engine_idx, engine)
 
         else:
             job.error("Invalid engine '%s' for prove mode." % engine[0])
-


### PR DESCRIPTION
Compared to the `select` event loop, using the event loop provided by `asyncio` for `sby_core` offers improvements in portability and reduces the code used for manaual event management, with minimal increase in the lines of code. Unix functionality is (almost completely- see signal handlers) unaffected, while Windows support gains feature-parity with Unix.

## Summary of Changes
As part of this PR, `taskloop`'s semantics have changed (`task` in this context means `async def`). Instead of waiting on `fd`s, `taskloop` now waits on `SbyTask` termination or `SbyJob` timeout. The following tasks are run:
* `maybe_spawn` will spawn a subprocess associated with `SbyTask` if all `SbyTasks` it depends on is finished.
* The `output` `task` will collect lines of `stdout`. This happens in parallel with waiting for `SbyTask` termination.
* `shutdown_and_notify` will do cleanup and then run `maybe_spawn` on all `SbyTask`s in `self.notify`.
* `timekeeper` handles global timeout of `SbyJob`.
* Once the `task_poller` task returns (be it termination, timeout, or completion), the event loop shuts itself down.

## Improvements
* Improves Windows support while only using Python's standard library; tasks can now run in parallel without relying on Unix-specific `select` functionality.
* _From my perception_, an overall cleanup of `taskloop`:
  * `taskloop` will not iterate unless an event occurred (contrast to the timeout parameter of `select`.
  * There is no longer any need to poll tasks that have not started; process termination is monitored by the asynchronous event loop. Every time a task finishes, `taskloop` will make sure to attempt to start pending tasks before beginning a new iteration.  
  * Timeout and task termination is handled automatically by the asynchronous event loop.
  * Tasks no longer need to be polled regularly for output; this happens transparently.
 
## Disadvantages
* I had to add a workaround for Windows to ensure the Python interpreter actually exits when the event loop completes. I have no idea where in the stack to look (msys2 implementation bug? Python bug?), so I'm looking into creating an MVCE to duplicate the problem and ask for help. 

  That said, the code works correctly in my testing on Windows, and better than what is currently there. This is more of a complaint that a workaround is needed at all (_the `tasks_retired` member of `SbyTask` exists solely for this workaround_).
* `SbyTasks` no longer spawn subprocesses; this is now `taskloop`'s responsbility. Python constructors cannot be asynchronous and the various workarounds I've found require large swaths of `SymbiYosys` to become `async` rather than just the `taskloop`. In my opinion, this is more trouble than it is worth for a few milliseconds less latency in getting tasks running initially. I renamed `run()` functions to `init()` to reflect the changes.
* Signal handlers should be async using `AbstractEventLoop.add_signal_handler()`. At present, there is [no way](https://docs.python.org/3/library/asyncio-platforms.html#windows) to do this portably. This results in messages like the following when CTRL+C is pressed:

### Windows
```
SBY 23:27:36 [sbysrc\demo3] engine_1: ##   0:00:00  Checking assertions in step 15..
SBY 23:27:36 [sbysrc\demo3] engine_0: ##   0:00:00  Checking assumptions in step 8..
SBY 23:27:36 [sbysrc\demo3] engine_0: ##   0:00:00  Checking assertions in step 8..
Task exception was never retrieved
future: <Task finished coro=<SbyTask.output() done, defined at C:\msys64\mingw64\bin/../share/yosys/python3\sby_core.py:121> exception=RuntimeError("reentrant call inside <_io.BufferedWriter name='<stdout>'>",)>
Traceback (most recent call last):
  File "C:\msys64\mingw64\bin/../share/yosys/python3\sby_core.py", line 132, in output
    self.handle_output(outs)
  File "C:\msys64\mingw64\bin/../share/yosys/python3\sby_core.py", line 90, in handle_output
    self.job.log("%s: %s" % (self.info, line))
  File "C:\msys64\mingw64\bin/../share/yosys/python3\sby_core.py", line 292, in log
    print("SBY %2d:%02d:%02d [%s] %s" % (tm.tm_hour, tm.tm_min, tm.tm_sec, self.workdir, logmessage), flush=True)
  File "C:\msys64\mingw64\bin/../share/yosys/python3\sby_core.py", line 33, in force_shutdown
    print("SBY ---- Keyboard interrupt or external termination signal ----", flush=True)
RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>
SBY 23:27:36 [sbysrc\demo3] engine_1: ##   0:00:00  Unexpected response from solver: unknown
SBY 23:27:36 [sbysrc\demo3] engine_1: <SIGINT>
SBY 23:27:36 [sbysrc\demo3] engine_0: finished (returncode=1)
SBY 23:27:36 [sbysrc\demo3] ERROR: engine_0: Engine terminated without status.
SBY 23:27:36 [sbysrc\demo3] engine_1: terminating process
SBY 23:27:36 [sbysrc\demo3] DONE (ERROR, rc=16)
```

### Unix
This warning comparatively rare. I've not been able to cause an error on Unix. `AbstractEventLoop.add_signal_handler()` can solve this, but since signals become events in the event loop, the `sys.exit(1)` line would need to be moved until after the loop finishes (i.e. `task_poller` returns). Current behavior is to exit immediately in `force_shutdown`.

```
SBY 23:13:05 [sbysrc/demo3] engine_0: ##   0:00:00  Checking assertions in step 15..
SBY 23:13:05 [sbysrc/demo3] engine_1: ##   0:00:00  Checking assumptions in step 35..
^CSBY ---- Keyboard interrupt or external termination signal ----
SBY 23:13:05 [sbysrc/demo3] engine_0: terminating process
SBY 23:13:05 [sbysrc/demo3] engine_1: terminating process
Task was destroyed but it is pending!
source_traceback: Object created at (most recent call last):
  File "/home/william/.local/bin/sby", line 388, in <module>
    retcode |= run_job(t)
  File "/home/william/.local/bin/sby", line 346, in run_job
    job.run(setupmode)
  File "/home/william/.local/bin/../share/yosys/python3/sby_core.py", line 660, in run
    self.taskloop()
  File "/home/william/.local/bin/../share/yosys/python3/sby_core.py", line 242, in taskloop
    loop.run_until_complete(poll_fut)
  File "/usr/lib/python3.5/asyncio/base_events.py", line 375, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.5/asyncio/base_events.py", line 345, in run_forever
    self._run_once()
  File "/usr/lib/python3.5/asyncio/base_events.py", line 1304, in _run_once
    handle._run()
  File "/usr/lib/python3.5/asyncio/events.py", line 125, in _run
    self._callback(*self._args)
  File "/usr/lib/python3.5/asyncio/tasks.py", line 307, in _wakeup
    self._step()
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/home/william/.local/bin/../share/yosys/python3/sby_core.py", line 277, in task_poller
    await task.shutdown_and_notify()
  File "/usr/lib/python3.5/asyncio/coroutines.py", line 105, in __next__
    return self.gen.send(None)
  File "/home/william/.local/bin/../share/yosys/python3/sby_core.py", line 181, in shutdown_and_notify
    await next_task.maybe_spawn()
  File "/usr/lib/python3.5/asyncio/coroutines.py", line 105, in __next__
    return self.gen.send(None)
  File "/home/william/.local/bin/../share/yosys/python3/sby_core.py", line 161, in maybe_spawn
    asyncio.ensure_future(self.output())
task: <Task pending coro=<SbyTask.output() running at /home/william/.local/bin/../share/yosys/python3/sby_core.py:124> created at /home/william/.local/bin/../share/yosys/python3/sby_core.py:161>
```

## Testing
I have tested this PR on Windows (MSYS2) and Linux (Ubuntu) using the `demo3.sby` script with an extra solver: `smtbmc z3`. I also tested timeout and `^C` handling.

cc: @q3k and @whitequark I would also like your feedback.