### PR TITLE
Switch from getopt to argparse

### DIFF
--- a/sbysrc/sby.py
+++ b/sbysrc/sby.py
@@ -41,6 +41,7 @@ parser.add_argument("-b", action="store_true", dest="backup",
 parser.add_argument("-t", action="store_true", dest="tmpdir",
         help="run in a temporary workdir (remove when finished)")
 parser.add_argument("-T", metavar="<taskname>", action="append", dest="tasknames",
+        default=list(),
         help="add taskname (useful when sby file is read from stdin, ignored if tasknames are given as positional arguments)")
 parser.add_argument("-E", action="store_true", dest="throw_err",
         help="throw an exception (incl stack trace) for most errors")


### PR DESCRIPTION
Issue #25 suggested switching from getopt to argparse. This patch makes that change in isolation.

Advantages include:
1. Not needing to maintain the usage documentation by adding new options or removing retired options, which often gets out-of-sync with the implementation.
2. Less code to maintain. The logic of parsing the arguments is built into argparse.
3. Simplified type checking for arguments. Not used in this patch to keep the diff minimal.
4. Namespace for arguments. This patch uses the existing variables to keep the diff minimal.

Feel free to reject the pull, but please reject #25, as I was also led astray like #50 into thinking the idea came from a more authoritative source. I had a local copy of these changes before seeing #50, but it looks like that pull request also changes/breaks some functionality for tasks.