### PR TITLE
sby_core: Tweak POSIX/Windows functionality gates.

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -18,7 +18,8 @@
 
 import os, re, sys
 if os.name == "posix":
-    import resource, fcntl, signal
+    import resource, fcntl
+import signal
 import subprocess
 from shutil import copyfile, rmtree
 from select import select
@@ -242,10 +243,11 @@ class SbyJob:
                 if task.running:
                     fds.append(task.p.stdout)
 
-            try:
-                select(fds, [], [], 1.0) == ([], [], [])
-            except InterruptedError:
-                pass
+            if os.name == "posix":
+                try:
+                    select(fds, [], [], 1.0) == ([], [], [])
+                except InterruptedError:
+                    pass
 
             for task in self.tasks_running:
                 task.poll()


### PR DESCRIPTION
I needed to use `sby` on Windows again, and it required a few minor changes to make it work. `posix` support is unaffected; I just needed to move an import and add a `if os.name == "posix"` gate.