### PR TITLE
Allow environment variables for make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
-DESTDIR =
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 
 # On Windows, manually setting absolute path to Python binary may be required
 # for launcher executable to work. From MSYS2, this can be done using the


### PR DESCRIPTION
Add the option of setting the install path variables by using
environment variables without the need to use the '-e' flag, as this is
not a recommended practice.
Another option would be to override the variables with command line
arguments, but using the environment variables is quite common.