### PR TITLE
Inject executable dependencies from the environment

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -221,14 +221,14 @@ class SbyJob:
         self.expect = []
 
         self.exe_paths = {
-            "yosys": "yosys",
-            "abc": "yosys-abc",
-            "smtbmc": "yosys-smtbmc",
-            "suprove": "suprove",
-            "aigbmc": "aigbmc",
-            "avy": "avy",
-            "btormc": "btormc",
-            "pono": "pono",
+            "yosys": os.getenv("YOSYS", "yosys"),
+            "abc": os.getenv("ABC", "yosys-abc"),
+            "smtbmc": os.getenv("SMTBMC", "yosys-smtbmc"),
+            "suprove": os.getenv("SUPROVE", "suprove"),
+            "aigbmc": os.getenv("AIGBMC", "aigbmc"),
+            "avy": os.getenv("AVY", "avy"),
+            "btormc": os.getenv("BTORMC", "btormc"),
+            "pono": os.getenv("PONO", "pono"),
         }
 
         self.tasks_running = []


### PR DESCRIPTION
I'm now shipping `yosys-smtbmc` in YoWASP as `yowasp-yosys-smtbmc`, however today using it would require altering user scripts to add the `--yosys` and `--smtbmc` options so that the properly prefixed binary is used. This PR makes it possible to do the same through the environment.

Unresolved questions:
  * Should smtbmc be looked up in the `YOSYS_SMTBMC` environment variable? I'm not sure if "smtbmc" is a general interface for which Yosys provides an implementation (then it should be `SMTBMC`), or something Yosys-specific (then it should be `YOSYS_SMTBMC`).