### PR TITLE
Use latest windows python launcher from yosys

### DIFF
--- a/extern/launcher.c
+++ b/extern/launcher.c
@@ -61,10 +61,11 @@ SOFTWARE. */
 #include <windows.h>
 #include <tchar.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 int child_pid=0;
 
-int fail(char *format, char *data) {
+int fail(const char *format, const char *data) {
     /* Print error message to stderr and return 2 */
     fprintf(stderr, format, data);
     return 2;
@@ -75,7 +76,7 @@ char *quoted(char *data) {
 
     /* We allocate twice as much space as needed to deal with worse-case
        of having to escape everything. */
-    char *result = calloc(ln*2+3, sizeof(char));
+    char *result = (char *)calloc(ln*2+3, sizeof(char));
     char *presult = result;
 
     *presult++ = '"';
@@ -119,7 +120,7 @@ char *loadable_exe(char *exename) {
     if (!hPython) return NULL; */
 
     /* Return the absolute filename for spawnv */
-    result = calloc(MAX_PATH, sizeof(char));
+    result = (char *)calloc(MAX_PATH, sizeof(char));
     strncpy(result, exename, MAX_PATH);
     /*if (result) GetModuleFileNameA(hPython, result, MAX_PATH);
 
@@ -157,7 +158,7 @@ char **parse_argv(char *cmdline, int *argc)
 {
     /* Parse a command line in-place using MS C rules */
 
-    char **result = calloc(strlen(cmdline), sizeof(char *));
+    char **result = (char **)calloc(strlen(cmdline), sizeof(char *));
     char *output = cmdline;
     char c;
     int nb = 0;
@@ -338,7 +339,7 @@ int run(int argc, char **argv, int is_gui) {
 
     if (is_gui) {
         /* Use exec, we don't need to wait for the GUI to finish */
-        execv(ptr, (const char * const *)(newargs));
+        execv(ptr, (char * const *)(newargs));
         return fail("Could not exec %s", ptr);   /* shouldn't get here! */
     }
 


### PR DESCRIPTION
I was told on IRC that sby doesn't necessarily completely work on Windows at the moment, but while investigating I ran into some minor errors compiling the launcher with MinGW. I thought it would be worth updating it to incorporate the modifications from Yosys to ease any future efforts around Windows support.