### PR TITLE
rename make test to make ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 	chmod +x $(DESTDIR)$(PREFIX)/bin/sby
 endif
 
-test: \
+ci: \
   test_demo1 test_demo2 test_demo3 \
   test_abstract_abstr test_abstract_props \
   test_demos_fib_cover test_demos_fib_prove test_demos_fib_live \
@@ -49,7 +49,7 @@ test: \
   test_quickstart_demo test_quickstart_cover test_quickstart_prove test_quickstart_memory \
   run_tests
 	if yosys -qp 'read -verific' 2> /dev/null; then set -x; \
-		YOSYS_NOVERIFIC=1 $(MAKE) test; \
+		YOSYS_NOVERIFIC=1 $(MAKE) ci; \
 	fi
 
 test_demo1:


### PR DESCRIPTION
Having a make target named `test` naturally leads people to expect that they can and should run the usual sequence of `make`, `make test`, and `make install` (see e.g. #112). However our current test target breaks with the usual `make test` conventions in several ways, as it depends on having every single third-party solver and utility installed, some of which are not documented yet and some of which aren't available on all platforms. Users wouldn't be expected to install all of them, only those they want to use.

To avoid giving a false impression of what the make target does, rename it to `ci` instead.