### PR TITLE
make install: mac OS compatible sed usage 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/share/yosys/python3
 	cp sbysrc/sby_*.py $(DESTDIR)$(PREFIX)/share/yosys/python3/
-	sed -e 's|##yosys-program-prefix##|"'$(PROGRAM_PREFIX)'"|' -i $(DESTDIR)$(PREFIX)/share/yosys/python3/sby_core.py
+	sed -e 's|##yosys-program-prefix##|"'$(PROGRAM_PREFIX)'"|' < sbysrc/sby_core.py > $(DESTDIR)$(PREFIX)/share/yosys/python3/sby_core.py
 ifeq ($(OS), Windows_NT)
 	sed -e 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' \
 		-e "s|#!/usr/bin/env python3|#!$(PYTHON)|" < sbysrc/sby.py > $(DESTDIR)$(PREFIX)/bin/sby-script.py


### PR DESCRIPTION
`sed -i` (in-place replacement) is not a posix option. Unfortunately, while the option exists both in GNU and BSD sed, it has incompatible argument syntax (for specifying the extension to use for the backup file).
In GNU sed, the argument is optional and should be appended without space: `-i[SUFFIX]`
In BSD sed, the argument is mandatory and comes after a space: `[-i extension]`

Since these two can't be reconciled, don't use the in-place option. Instead read from the original source file and write to the install location.